### PR TITLE
Add missing CALL on Fortran SHMEM_INFO routines

### DIFF
--- a/content/shmem_info_get_name.tex
+++ b/content/shmem_info_get_name.tex
@@ -11,7 +11,7 @@ void shmem_info_get_name(char *name);
 
 \begin{Fsynopsis}
 CHARACTER *(*)NAME
-SHMEM_INFO_GET_NAME(NAME)   
+CALL SHMEM_INFO_GET_NAME(NAME)
 \end{Fsynopsis}
 
 \begin{apiarguments}

--- a/content/shmem_info_get_version.tex
+++ b/content/shmem_info_get_version.tex
@@ -10,7 +10,7 @@ void shmem_info_get_version(int *major, int *minor);
 
 \begin{Fsynopsis}
 INTEGER MAJOR, MINOR
-SHMEM_INFO_GET_VERSION(MAJOR, MINOR)   
+CALL SHMEM_INFO_GET_VERSION(MAJOR, MINOR)
 \end{Fsynopsis}
 
 \begin{apiarguments}


### PR DESCRIPTION
I don't know any Fortran, but I know consistency. The Fortran SHMEM_INFO routines are missing `CALL`.