### PR TITLE
Edits to drafts/osh-1.4-rc5 to facillitate manpage generation

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -219,11 +219,11 @@ CALL @\FuncDecl{SHMEM\_INT8\_XOR\_TO\_ALL}@(dest, source, nreduce, PE_start, log
 }
 
 
-{
+
 \deprecationstart
 \apidesctable{
     When calling from \Fortran, the \dest{} date types are as follows:
-}{Routine}{Data type}{
+}{Routine}{Data type}
     \apitablerow{shmem\_int8\_and\_to\_all}{Integer, with an element size of 8 bytes.}
     \apitablerow{shmem\_int4\_and\_to\_all}{Integer, with an element size of 4 bytes.}
     \apitablerow{shmem\_comp8\_max\_to\_all}{Complex, with an element size equal to two 8-byte real values.}
@@ -254,9 +254,9 @@ CALL @\FuncDecl{SHMEM\_INT8\_XOR\_TO\_ALL}@(dest, source, nreduce, PE_start, log
     \apitablerow{shmem\_int4\_or\_to\_all}{Integer, with an element size of 4 bytes.}
     \apitablerow{shmem\_int8\_xor\_to\_all}{Integer, with an element size of 8 bytes.}
     \apitablerow{shmem\_int4\_xor\_to\_all}{Integer, with an element size of 4 bytes.}
-}
+
 \deprecationend
-}
+
 
 \apireturnvalues{
     None.

--- a/content/shpdeallc.tex
+++ b/content/shpdeallc.tex
@@ -1,0 +1,41 @@
+\apisummary{
+    Returns a memory block to the symmetric heap.
+}
+
+\begin{apidefinition}
+
+\begin{Fsynopsis}
+POINTER (addr, A(1))
+INTEGER errcode, abort
+CALL @\FuncDecl{SHPDEALLC}@(addr, errcode, abort)
+\end{Fsynopsis}
+
+\begin{apiarguments}
+    \apiargument{IN}{addr}{ First word address of the block to deallocate.}
+    \apiargument{OUT}{errcode}{Error  code is 0 if no error was detected;
+    otherwise, it is a  negative integer code for the type of error.}
+    \apiargument{IN}{abort}{Abort code.  Nonzero requests abort on error;
+    \CONST{0} requests an error code.}
+\end{apiarguments}
+
+\apidescription{
+    SHPDEALLC returns a block of memory (allocated using \FUNC{SHPALLOC}) to the
+    list of available space in the symmetric heap.  To maintain symmetric heap
+    consistency, all \acp{PE} in a program must call \FUNC{SHPDEALLC} with the same
+    value of \VAR{addr}; if any \acp{PE}  are missing, the program hangs.
+}
+
+\apireturnvalues{}
+    \apitablerow{Error Code}{Condition}
+    \apitablerow{ \CONST{-1} }{Length is not an integer greater than 0}
+    \apitablerow{\CONST{-2}}{No more memory is available from the system (checked if the
+    request cannot be satisfied from the available blocks on the symmetric heap).}
+    \apitablerow{\CONST{-3}}{Address is outside the bounds of the symmetric heap.}
+    \apitablerow{\CONST{-4}}{Block is already free.}
+    \apitablerow{\CONST{-5}}{Address is not at the beginning of a block.}
+
+\apinotes{
+    None.
+}   
+
+\end{apidefinition}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -112,8 +112,8 @@ symmetric data objects in the symmetric heap.
 \subsubsection{\textbf{SHPCLMOVE}}\label{subsec:shpclmove}
 \input{content/shpclmove.tex}
 
-\subsubsection{\textbf{SHPDEALLOC}}\label{subsec:shpdealloc}
-\input{content/shpdealloc.tex}
+\subsubsection{\textbf{SHPDEALLC}}\label{subsec:shpdealloc}
+\input{content/shpdeallc.tex}
 
 
 \subsection{Communication Management Routines}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -112,7 +112,7 @@ symmetric data objects in the symmetric heap.
 \subsubsection{\textbf{SHPCLMOVE}}\label{subsec:shpclmove}
 \input{content/shpclmove.tex}
 
-\subsubsection{\textbf{SHPDEALLC}}\label{subsec:shpdealloc}
+\subsubsection{\textbf{SHPDEALLOC}}\label{subsec:shpdealloc}
 \input{content/shpdealloc.tex}
 
 
@@ -275,7 +275,7 @@ default context.  The default context can be used explicitly through the
 \subsection{Point-To-Point Synchronization Routines}\label{subsec:p2p_intro}
 \input{content/p2p_sync_intro.tex}
 
-\subsubsection{\textbf{SHMEM\_WAIT\_UNTIL}}\label{subsec:shmem_wait}
+\subsubsection{\textbf{SHMEM\_WAIT}}\label{subsec:shmem_wait}
 \input{content/shmem_wait.tex}
 
 \subsubsection{\textbf{SHMEM\_TEST}}\label{subsec:shmem_test}


### PR DESCRIPTION
Changed main_spec.tex to maintain consistency between the names of the tex files and the names of the functions.

Got rid of extra braces in shmem_reductions.tex that were showing in the manpages.