### PR TITLE
Replace default team with world team

### DIFF
--- a/content/context_intro.tex
+++ b/content/context_intro.tex
@@ -1,0 +1,45 @@
+All \openshmem \ac{RMA}, \ac{AMO}, and memory ordering routines must be
+performed on a valid communication context.  The communication context defines an
+independent ordering and completion environment, allowing users to manage the
+overlap of communication with computation and also to manage communication
+operations performed by separate threads within a multithreaded \ac{PE}.  For
+example, in single-threaded environments, contexts may be used to pipeline
+communication and computation.  In multithreaded environments, contexts may
+additionally provide thread isolation, eliminating overheads resulting from
+thread interference.
+
+A specific communication context is referenced through a context handle, which is
+passed as an argument in the \Cstd \CTYPE{shmem\_ctx\_*} and type-generic \ac{API}
+routines.  \ac{API} routines that do not accept a context handle argument operate on the
+default context.  The default context can be used explicitly through the
+\LibHandleRef{SHMEM\_CTX\_DEFAULT} handle.
+Context handles are of type \CTYPE{shmem\_ctx\_t} and may be used for
+language-level assignment and equality comparison.
+
+The default context is valid for the duration of the \openshmem portion of
+an application.
+Contexts created by a successful call to \FUNC{shmem\_ctx\_create} remain
+valid until they are destroyed.
+A handle value that does not correspond to a valid context is considered
+to be invalid, and its use in \ac{RMA} and \ac{AMO} routines results in
+undefined behavior.
+A context handle may be initialized to or assigned the value
+\CONST{SHMEM\_CTX\_INVALID} to indicate that handle does not reference a
+valid communication context.
+When managed in this way, applications can use an equality comparison
+to test whether a given context handle references a valid context.
+
+Every communication context is associated with a team.
+This association is established at context creation.
+Communication contexts created by \FUNC{shmem\_ctx\_create} are
+associated with the world team, while contexts created by
+\FUNC{shmem\_team\_create\_ctx} are associated with and created from a team
+specified at context creation.
+The default context is associated with the world team.
+A context's associated team specifies the set of \acp{PE} over which
+\ac{PE}-specific routines that operate on a communication context,
+explicitly or implicitly, are performed.
+All point-to-point routines that operate on this context will do so with
+respect to the team-relative \ac{PE} numbering of the associated team.
+If the PE number passed to such a routine is invalid, being negative or greater
+than or equal to the size of the \openshmem team, then the behavior is undefined.

--- a/content/shmem_ctx_create.tex
+++ b/content/shmem_ctx_create.tex
@@ -29,7 +29,7 @@ int @\FuncDecl{shmem\_ctx\_create}@(long options, shmem_ctx_t *ctx);
     options or after additional resources become available.
 
     A newly created communication context has a fixed association with the
-    default team.
+    world team.
     All \openshmem routines that operate on this context will do so with
     respect to the associated \ac{PE} team.
     That is, all point-to-point routines operating on this context will use

--- a/content/shmem_team_destroy.tex
+++ b/content/shmem_team_destroy.tex
@@ -24,7 +24,7 @@ created from this team with the \CONST{SHMEM\_CTX\_PRIVATE} option
 enabled prior to calling this routine; otherwise, the behavior is
 undefined.
 
-It is an error to destroy the default team or any other predefined team.
+It is an error to destroy the world team or any other predefined team.
 
 If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID},
 then no operation is performed.

--- a/content/shmem_team_my_pe.tex
+++ b/content/shmem_team_my_pe.tex
@@ -31,7 +31,7 @@ int @\FuncDecl{shmem\_team\_my\_pe}@(shmem_team_t team);
 }
 
 \apinotes{
-  For the default team, this routine will return the same value as
+  For the world team, this routine will return the same value as
   \FUNC{shmem\_my\_pe}.
 }
 

--- a/content/shmem_team_n_pes.tex
+++ b/content/shmem_team_n_pes.tex
@@ -31,7 +31,7 @@ int @\FuncDecl{shmem\_team\_n\_pes}@(shmem_team_t team);
 }
 
 \apinotes{
-  For the default team, this routine will return the same value as
+  For the world team, this routine will return the same value as
   \FUNC{shmem\_n\_pes}.
 }
 

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -110,7 +110,7 @@ will be created and \VAR{new\_team} will be assigned the value
     \apicexample
     {The following example demonstrates the use of strided split in a
     \Cstd[11] program. The program creates a new team of all even number
-    \acp{PE} from the default team, then retrieves the \ac{PE} number and
+    \acp{PE} from the world team, then retrieves the \ac{PE} number and
     team size on all \acp{PE} that are members of the new team.}
     {./example_code/shmem_team_split_strided.c}
     {}

--- a/content/shmem_team_translate_pe.tex
+++ b/content/shmem_team_translate_pe.tex
@@ -46,9 +46,9 @@ team handle arguments are invalid or the \VAR{src\_pe} is not in both the source
     \apicexample
     {The following example demonstrates the use of the team \ac{PE}
     number translation routine. The program makes a new team of all
-    of the even number \acp{PE} in the default team. Then, all \acp{PE}
+    of the even number \acp{PE} in the world team. Then, all \acp{PE}
     in the new team acquire their \ac{PE} number in the new team
-    and translate it to the \ac{PE} number in the default team.}
+    and translate it to the \ac{PE} number in the world team.}
     {./example_code/shmem_team_translate_pe.c}
     {}
 

--- a/content/teams_intro.tex
+++ b/content/teams_intro.tex
@@ -32,10 +32,10 @@ The predefined teams may be accessed via the team handles listed in
 Section~\ref{subsec:library_handles}.
 
 \openshmem communication routines that do not accept a team handle
-argument operate on the default team, which may be accessed through
+argument operate on the world team, which may be accessed through
 the \LibHandleRef{SHMEM\_TEAM\_WORLD} handle.
-The default team encompasses the set of all \acp{PE} in the \openshmem
-program, and a \ac{PE} number in the default team is the same as the
+The world team encompasses the set of all \acp{PE} in the \openshmem
+program, and a \ac{PE} number in the world team is the same as the
 value returned by \FUNC{shmem\_my\_pe}.
 
 A team handle may be initialized to or assigned the value

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -174,10 +174,10 @@ to test whether a given context handle references a valid context.
 Every communication context is associated with a team.
 This association is established at context creation.
 Communication contexts created by \FUNC{shmem\_ctx\_create} are
-associated with the default team, while contexts created by
+associated with the world team, while contexts created by
 \FUNC{shmem\_team\_create\_ctx} are associated with and created from a team
 specified at context creation.
-The default context is associated with the default team.
+The default context is associated with the world team.
 A context's associated team specifies the set of \acp{PE} over which
 \ac{PE}-specific routines that operate on a communication context,
 explicitly or implicitly, are performed.

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -138,53 +138,8 @@ symmetric data objects in the symmetric heap.
 
 
 
-\subsection{Communication Management Routines}
-\label{sec:ctx}
-All \openshmem \ac{RMA}, \ac{AMO}, and memory ordering routines must be
-performed on a valid communication context.  The communication context defines an
-independent ordering and completion environment, allowing users to manage the
-overlap of communication with computation and also to manage communication
-operations performed by separate threads within a multithreaded \ac{PE}.  For
-example, in single-threaded environments, contexts may be used to pipeline
-communication and computation.  In multithreaded environments, contexts may
-additionally provide thread isolation, eliminating overheads resulting from
-thread interference.
-
-A specific communication context is referenced through a context handle, which is
-passed as an argument in the \Cstd \CTYPE{shmem\_ctx\_*} and type-generic \ac{API}
-routines.  \ac{API} routines that do not accept a context handle argument operate on the
-default context.  The default context can be used explicitly through the
-\LibHandleRef{SHMEM\_CTX\_DEFAULT} handle.
-Context handles are of type \CTYPE{shmem\_ctx\_t} and may be used for
-language-level assignment and equality comparison.
-
-The default context is valid for the duration of the \openshmem portion of
-an application.
-Contexts created by a successful call to \FUNC{shmem\_ctx\_create} remain
-valid until they are destroyed.
-A handle value that does not correspond to a valid context is considered
-to be invalid, and its use in \ac{RMA} and \ac{AMO} routines results in
-undefined behavior.
-A context handle may be initialized to or assigned the value
-\CONST{SHMEM\_CTX\_INVALID} to indicate that handle does not reference a
-valid communication context.
-When managed in this way, applications can use an equality comparison
-to test whether a given context handle references a valid context.
-
-Every communication context is associated with a team.
-This association is established at context creation.
-Communication contexts created by \FUNC{shmem\_ctx\_create} are
-associated with the world team, while contexts created by
-\FUNC{shmem\_team\_create\_ctx} are associated with and created from a team
-specified at context creation.
-The default context is associated with the world team.
-A context's associated team specifies the set of \acp{PE} over which
-\ac{PE}-specific routines that operate on a communication context,
-explicitly or implicitly, are performed.
-All point-to-point routines that operate on this context will do so with
-respect to the team-relative \ac{PE} numbering of the associated team.
-If the PE number passed to such a routine is invalid, being negative or greater
-than or equal to the size of the \openshmem team, then the behavior is undefined.
+\subsection{Communication Management Routines}\label{sec:ctx}
+\input{content/context_intro.tex}
 
 \subsubsection{\textbf{SHMEM\_CTX\_CREATE}}
 \label{subsec:shmem_ctx_create}


### PR DESCRIPTION
This PR contains two changes:
- Replace default team with world team. Resolves #371 for the teams and context sections. 
- Move the introduction part into a separate file, similar to other sections.