### PR TITLE
Generalize team split 2D example for any # of PEs

### DIFF
--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -146,100 +146,96 @@ See the description of team handles and predefined teams at the top of section
     \apicexample
     {The following example demonstrates the use of 2D Cartesian split in a
     \Cstd[11] program. This example shows how multiple 2D splits can be used
-    to generate a 3D Cartesian split. This method can be extrapolated to
-    generate splits of any number of dimensions.}
+    to generate a 3D Cartesian split.}
     {./example_code/shmem_team_split_2D.c}
     {
     The example above splits \LibHandleRef{SHMEM\_TEAM\_WORLD} into a 3D team
-    with dimensions 3x4xN.  For example, if \VAR{npes} = 16,  \VAR{xdim} = 3,
-    and \VAR{ydim} = 4, then the final dimensions are 3x4x2.  In this case, the
-    first split of \LibHandleRef{SHMEM\_TEAM\_WORLD} results in 6 \VAR{xteams}
-    and 3 \VAR{yzteams}:
+    with dimensions \VAR{xdim}, \VAR{ydim}, and \VAR{zdim}, where each
+    dimension is calculated using the functions, \FUNC{find\_xy\_dims} and
+    \FUNC{find\_xyz\_dims}.  When running with 12 \acp{PE}, the dimensions
+    are 3x2x2, respectively, and the first split of
+    \LibHandleRef{SHMEM\_TEAM\_WORLD} results in 4 \VAR{xteams} and 3
+    \VAR{yzteams}:
 
     \begin{center}
     \begin{tabular}{|l|l|l|l|l|}
      \hline
       \multicolumn{2}{|c|}{} & \multicolumn{3}{c|}{\VAR{yzteam}} \\ \cline{3-5}
       \multicolumn{2}{|c|}{} & \VAR{x} = 0 & \VAR{x} = 1 & \VAR{x} = 2  \\ \hline
-\multirow{6}{*}{\VAR{xteam}} & \VAR{yz} = 0  & 0   & 1   & 2  \\ \cline{2-5}
+\multirow{4}{*}{\VAR{xteam}} & \VAR{yz} = 0  & 0   & 1   & 2  \\ \cline{2-5}
                              & \VAR{yz} = 1  & 3   & 4   & 5  \\ \cline{2-5}
                              & \VAR{yz} = 2  & 6   & 7   & 8  \\ \cline{2-5}
-                             & \VAR{yz} = 3  & 9   & 10 &  11 \\ \cline{2-5}
-                             & \VAR{yz} = 4  & 12  & 13 & 14  \\ \cline{2-5}
-                             & \VAR{yz} = 5  & 15  \\
+                             & \VAR{yz} = 3  & 9   & 10  & 11 \\ \cline{2-5}
      \cline{0-2}
     \end{tabular}
     \end{center}
 
-    The second split of \VAR{yzteam} for \VAR{x} = 0, \VAR{ydim} = 4 results in 2
-    \VAR{yteams} and 4 \VAR{zteams}:
+    The second split of \VAR{yzteam} for \VAR{x} = 0, \VAR{ydim} = 2 results in 2
+    \VAR{yteams} and 2 \VAR{zteams}:
 
 
     \begin{center}
-    \begin{tabular}{|l|l|l|l|l|l|}
+    \begin{tabular}{|l|l|l|l|}
      \hline
-      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
-      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
-\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 0    & 3    & 6  & 9 \\ \cline{2-6}
-                             & \VAR{z} = 1  & 12   & 15 \\
+      \multicolumn{2}{|c|}{} & \multicolumn{2}{c|}{\VAR{zteam}} \\ \cline{3-4}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0 & 0    & 3    \\ \cline{2-4}
+                             & \VAR{z} = 1 & 6    & 9    \\
      \cline{0-3}
     \end{tabular}
     \end{center}
 
-    The second split of \VAR{yzteam} for \VAR{x} = 1, \VAR{ydim} = 4 results in
-    2 \VAR{yteams} and 4 \VAR{zteams}:
+    The second split of \VAR{yzteam} for \VAR{x} = 1, \VAR{ydim} = 2 results in
+    2 \VAR{yteams} and 2 \VAR{zteams}:
 
     \begin{center}
-    \begin{tabular}{|l|l|l|l|l|l|}
+    \begin{tabular}{|l|l|l|l|}
      \hline
-      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
-      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
-\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 1    & 4    & 7  & 10 \\ \cline{2-6}
-                             & \VAR{z} = 1  & 13 \\
-     \cline{0-2}
+      \multicolumn{2}{|c|}{} & \multicolumn{2}{c|}{\VAR{zteam}} \\ \cline{3-4}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1        \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0 & 1    & 4           \\ \cline{2-4}
+                             & \VAR{z} = 1 & 7    & 10          \\
+     \cline{0-3}
     \end{tabular}
     \end{center}
 
-    The second split of \VAR{yzteam} for \VAR{x} = 2, \VAR{ydim} = 4 results in
-    2 \VAR{yteams} and 4 \VAR{zteams}:
+    The second split of \VAR{yzteam} for \VAR{x} = 2, \VAR{ydim} = 2 results in
+    2 \VAR{yteams} and 2 \VAR{zteams}:
 
     \begin{center}
-    \begin{tabular}{|l|l|l|l|l|l|}
+    \begin{tabular}{|l|l|l|l|}
      \hline
-      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
-      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
-\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 2    & 5    & 8  & 11 \\ \cline{2-6}
-                             & \VAR{z} = 1  & 14 \\
-     \cline{0-2}
+      \multicolumn{2}{|c|}{} & \multicolumn{2}{c|}{\VAR{zteam}} \\ \cline{3-4}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1        \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 2    & 5          \\ \cline{2-4}
+                             & \VAR{z} = 1  & 8    & 11         \\
+     \cline{0-3}
     \end{tabular}
     \end{center}
 
     The final number of teams for each dimension are:
     \begin{itemize}
-        \item 6 \VAR{xteams}: these are teams where (\VAR{z},\VAR{y}) is fixed and \VAR{x} varies.
+        \item 4 \VAR{xteams}: these are teams where (\VAR{z},\VAR{y}) is fixed and \VAR{x} varies.
         \item 6 \VAR{yteams}: these are teams where (\VAR{x},\VAR{z}) is fixed and \VAR{y} varies.
-        \item 12 \VAR{zteams}: these are teams where (\VAR{x},\VAR{y}) is fixed and \VAR{z} varies.
+        \item 6 \VAR{zteams}: these are teams where (\VAR{x},\VAR{y}) is fixed and \VAR{z} varies.
     \end{itemize}
 
-    The expected output is: \\
+    The expected output with 12 \acp{PE} is: \\
     \begin{small}
     \texttt{
-    (0, 0, 0) is me = 0  \\
-    (1, 0, 0) is me = 1  \\
-    (2, 0, 0) is me = 2  \\
-    (0, 1, 0) is me = 3  \\
-    (1, 1, 0) is me = 4  \\
-    (2, 1, 0) is me = 5  \\
-    (0, 2, 0) is me = 6  \\
-    (1, 2, 0) is me = 7  \\
-    (2, 2, 0) is me = 8  \\
-    (0, 3, 0) is me = 9  \\
-    (1, 3, 0) is me = 10 \\
-    (2, 3, 0) is me = 11 \\
-    (0, 0, 1) is me = 12 \\
-    (1, 0, 1) is me = 13 \\
-    (2, 0, 1) is me = 14 \\
-    (0, 1, 1) is me = 15
+    xdim = 3, ydim = 2, zdim = 2 \\
+    (0, 0, 0) is mype = 0        \\
+    (1, 0, 0) is mype = 1        \\
+    (2, 0, 0) is mype = 2        \\
+    (0, 1, 0) is mype = 3        \\
+    (1, 1, 0) is mype = 4        \\
+    (2, 1, 0) is mype = 5        \\
+    (0, 0, 1) is mype = 6        \\
+    (1, 0, 1) is mype = 7        \\
+    (2, 0, 1) is mype = 8        \\
+    (0, 1, 1) is mype = 9        \\
+    (1, 1, 1) is mype = 10       \\
+    (2, 1, 1) is mype = 11       \\
     }
     \end{small}
 }

--- a/example_code/shmem_team_split_2D.c
+++ b/example_code/shmem_team_split_2D.c
@@ -1,20 +1,39 @@
 #include <shmem.h>
 #include <stdio.h>
+#include <math.h>
+
+/*  Find x and y such that x * y == npes and abs(x - y) is minimized.  */
+void find_xy_dims(int npes, int *x, int *y) {
+  for(int divider = ceil(sqrt(npes)); divider >= 1; divider--)
+    if (npes % divider == 0) {
+      *x = divider;
+      *y = npes / divider;
+      return;
+    }
+}
+
+/*  Find x, y, and z such that x * y * z == npes and
+ *  abs(x - y) + abs(x - z) + abs(y - z) is minimized.  */
+void find_xyz_dims(int npes, int *x, int *y, int *z) {
+  for(int divider = ceil(cbrt(npes)); divider >= 1; divider--)
+    if (npes % divider == 0) {
+      *x = divider;
+      find_xy_dims(npes / divider, y, z);
+      return;
+    }
+}
 
 int main(void) {
-  int xdim = 3;
-  int ydim = 4;
+  int xdim, ydim, zdim;
 
   shmem_init();
   int mype = shmem_my_pe();
   int npes = shmem_n_pes();
 
-  if (npes < (xdim * ydim)) {
-    printf("Not enough PEs to create 4x3xN layout\n");
-    exit(1);
-  }
+  find_xyz_dims(npes, &xdim, &ydim, &zdim);
 
-  int zdim = (npes / (xdim * ydim)) + (((npes % (xdim * ydim)) > 0) ? 1 : 0);
+  if (shmem_my_pe() == 0) printf("xdim = %d, ydim = %d, zdim = %d\n", xdim, ydim, zdim);
+
   shmem_team_t xteam, yzteam, yteam, zteam;
 
   shmem_team_split_2d(SHMEM_TEAM_WORLD, xdim, NULL, 0, &xteam, NULL, 0, &yzteam);


### PR DESCRIPTION
This proposal changes the `shmem_team_split_2D` example program to support any number of PEs (it originally supported only 12 or more PEs).

It calculates the most "cube-like" configuration of `xdim` x `ydim` x `zdim`, given `npes`.

This new algorithm does not produce the same configuration as before when run with 16 PEs, so the accompanying explanation text needed to be changed.  I went with 12 PEs there to simplify and take up a little less space.