### PR TITLE
"Remote PE" fixes

### DIFF
--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -10,7 +10,7 @@ objects are stored in the local memory of each \ac{PE} and can only be accessed
 by the \ac{PE} itself; these data objects cannot be accessed by other \acp{PE}
 via \openshmem routines. Private data objects follow the memory model of
 \Cstd. Remotely accessible objects, however, can be accessed by
-remote \acp{PE} using \openshmem routines.  Remotely accessible data objects are
+target \acp{PE} using \openshmem routines.  Remotely accessible data objects are
 called \emph{Symmetric Data Objects}.  Each symmetric data object has a
 corresponding object with the same name, type, and size on all \acp{PE} where that object is
 accessible via the \openshmem \ac{API}\footnote{For efficiency reasons,

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -72,7 +72,7 @@ The ``mem'' interfaces (e.g., \FUNC{shmem\_putmem}) have no alignment
 requirements.
 
 The \FUNC{shmem\_ptr} and \FUNC{shmem\_team\_ptr} routines allow the application to query a {\em local
-address} to a remotely accessible data object at a specified \ac{PE}.  The
+address} to a remotely accessible data object at a specified target \ac{PE}.  The
 resulting pointer is valid for direct memory access; however, providing this
 address as an argument of an \openshmem routine that requires a symmetric
 address results in undefined behavior.

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -5,7 +5,7 @@ allows communication and synchronization operations on both private (local to
 the \ac{PE} initiating the operation) and remotely accessible data objects. The key
 feature of \openshmem is that data transfer operations are
 \emph{one-sided} in nature. This means that a local \ac{PE} executing
-a data transfer routine does not require the participation of the remote \ac{PE}
+a data transfer routine does not require the participation of the target \ac{PE}
 to complete the routine. This allows for overlap between communication and
 computation to hide data transfer latencies, which makes  \openshmem ideal for
 unstructured, small-to-medium-sized data communication patterns. The \openshmem
@@ -35,10 +35,10 @@ An overview of the \openshmem routines is described below:
    where the \acp{PE} are either single or multithreaded.
   \item \OPR{Query}: The local \ac{PE} may get the number of \acp{PE} running
       the same program and its unique integer identifier.
-  \item \OPR{Accessibility}: The local \ac{PE} can find out if a remote \ac{PE} is
+  \item \OPR{Accessibility}: The local \ac{PE} can find out if a target \ac{PE} is
       executing the same binary, or if a particular symmetric data object can be
-      accessed by a remote \ac{PE}, or may obtain a pointer to a symmetric data
-      object on the specified remote \ac{PE} on shared memory systems.
+      accessed by a target \ac{PE}, or may obtain a pointer to a symmetric data
+      object on the specified target \ac{PE} on shared memory systems.
 \end{enumerate}
 
 \item \textbf{Symmetric Data Object Management}
@@ -65,7 +65,7 @@ An overview of the \openshmem routines is described below:
     \acp{PE}. Teams are involved in both collective and point-to-point
     communication operations. Collective communication operations are performed
     on all \acp{PE} in a valid team and point-to-point communication operations
-    are performed between a local and remote \ac{PE} with team-based \ac{PE}
+    are performed between a local and target \ac{PE} with team-based \ac{PE}
     numbering through team-based contexts.
 \end{enumerate}
 
@@ -82,43 +82,43 @@ An overview of the \openshmem routines is described below:
 \item \textbf{\acfp{AMO}}
 \begin{enumerate}
   \item \OPR{Fetch}: The \ac{PE} initiating the fetch returns the value of the
-      symmetric data object on the remote \ac{PE}.
+      symmetric data object on the target \ac{PE}.
   \item \OPR{Set}: The \ac{PE} initiating the set copies a new value to the
-      symmetric data object on the remote \ac{PE}.
+      symmetric data object on the target \ac{PE}.
   \item \OPR{Swap}: The \ac{PE} initiating the swap copies a new value to the
-      symmetric data object on the remote \ac{PE} and returns the old value.
+      symmetric data object on the target \ac{PE} and returns the old value.
   \item \OPR{Increment}: The \ac{PE} initiating the increment adds 1 to the
-      symmetric data object on the remote \ac{PE}.
+      symmetric data object on the target \ac{PE}.
   \item \OPR{Add}: The \ac{PE} initiating the add specifies the value to be added
-      to the symmetric data object on the remote \ac{PE}.
+      to the symmetric data object on the target \ac{PE}.
   \item \OPR{Bitwise Operations}: The \ac{PE} initiating the bitwise
       operation specifies the operand value to the bitwise operation to be
-      performed on the symmetric data object on the remote \ac{PE}.
+      performed on the symmetric data object on the target \ac{PE}.
   \item \OPR{Compare and Swap}: The \ac{PE} initiating the compare and swap
       conditionally copies a new value to the symmetric data object on the
-      remote \ac{PE} and returns the old value.
+      target \ac{PE} and returns the old value.
   \item \OPR{Fetch and Increment}: The \ac{PE} initiating the increment adds 1
-      to the symmetric data object on the remote \ac{PE} and returns the old
+      to the symmetric data object on the target \ac{PE} and returns the old
       value.
   \item \OPR{Fetch and Add}: The \ac{PE} initiating the add specifies the value to
-      be added to the symmetric data object on the remote \ac{PE} and returns
+      be added to the symmetric data object on the target \ac{PE} and returns
       the old value.
   \item \OPR{Fetch and Bitwise Operations}: The \ac{PE} initiating the bitwise
       operation specifies the operand value to the bitwise operation to be
-      performed on the symmetric data object on the remote \ac{PE}
+      performed on the symmetric data object on the target \ac{PE}
       and returns the old value.
 \end{enumerate}
 
 \item \textbf{Signaling Operations}
 \begin{enumerate}
   \item \OPR{Put Signal}: The local \ac{PE} specifies the \source{} data object
-      to be copied to the symmetric data object on the remote \ac{PE} and
-      another symmetric data object on the remote \ac{PE} is subsequently
+      to be copied to the symmetric data object on the target \ac{PE} and
+      another symmetric data object on the target \ac{PE} is subsequently
       updated to signal completion.
   \item \OPR{Signal Add}: The local \ac{PE} specifies a value to be added to
-      the symmetric data object on the remote \ac{PE}.
+      the symmetric data object on the target \ac{PE}.
   \item \OPR{Signal Set}: The local \ac{PE} specifies a value to be copied to
-      the symmetric data object on the remote \ac{PE}.
+      the symmetric data object on the target \ac{PE}.
   \item \OPR{Signal Fetch}: The local \ac{PE} returns the value of a local data
       object.
 \end{enumerate}

--- a/content/shmem_addr_accessible.tex
+++ b/content/shmem_addr_accessible.tex
@@ -1,6 +1,6 @@
 \apisummary{
     Determines whether an address is accessible via \openshmem data transfer
-    routines from the specified remote \ac{PE}.
+    routines from the specified target \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -11,7 +11,7 @@ int @\FuncDecl{shmem\_addr\_accessible}@(const void *addr, int pe);
 
 \begin{apiarguments}
     \apiargument{IN}{addr}{Local address of data object to query.}
-    \apiargument{IN}{pe}{Integer id of a remote \ac{PE}.}
+    \apiargument{IN}{pe}{Integer id of a target \ac{PE}.}
 \end{apiarguments}
 
 \apidescription{
@@ -20,7 +20,7 @@ int @\FuncDecl{shmem\_addr\_accessible}@(const void *addr, int pe);
     specified \ac{PE} via \openshmem routines.
 
     This routine verifies that the data object is symmetric and accessible with
-    respect to a remote \ac{PE} via \openshmem data transfer routines.  The
+    respect to a target \ac{PE} via \openshmem data transfer routines.  The
     specified address \VAR{addr} is the local address of the data object on the
     local \ac{PE}.
 }
@@ -28,7 +28,7 @@ int @\FuncDecl{shmem\_addr\_accessible}@(const void *addr, int pe);
 \apireturnvalues{
     The return value is \CONST{1} if the local address \VAR{addr} is also a symmetric
     address and the given data object is accessible via \openshmem routines on
-    the specified remote \ac{PE}; otherwise, it is \CONST{0}.
+    the specified target \ac{PE}; otherwise, it is \CONST{0}.
 }
 
 \apinotes{

--- a/content/shmem_addr_accessible.tex
+++ b/content/shmem_addr_accessible.tex
@@ -17,7 +17,7 @@ int @\FuncDecl{shmem\_addr\_accessible}@(const void *addr, int pe);
 \apidescription{
     \FUNC{shmem\_addr\_accessible} is a query routine that indicates whether
     the address \VAR{addr} can be used to access the given data object on the
-    specified \ac{PE} via \openshmem routines.
+    specified target \ac{PE} via \openshmem routines.
 
     This routine verifies that the data object is symmetric and accessible with
     respect to a target \ac{PE} via \openshmem data transfer routines.  The

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -39,7 +39,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
         The type of \dest{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{value}{The operand to the atomic add operation.
         The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -51,7 +51,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
 \apidescription{
     The conditional swap routines conditionally update a \VAR{dest} data object on
-    the specified \ac{PE} and return the prior contents of the data object in one
+    the specified target \ac{PE} and return the prior contents of the data object in one
     atomic operation.
 }
 

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -43,9 +43,9 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
         unchanged.  In either case, the old value of the remote \VAR{dest} is
         returned as the routine return value. \VAR{cond} must be of the same data
         type as \VAR{dest}.}
-    \apiargument{IN}{value}{The value to be atomically written to the remote \ac{PE}.
+    \apiargument{IN}{value}{The value to be atomically written to the target \ac{PE}.
         The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_compare_swap_nbi.tex
+++ b/content/shmem_atomic_compare_swap_nbi.tex
@@ -35,7 +35,7 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
   \apiargument{IN}{value}{The value to be atomically written to the remote
       \ac{PE}.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -48,7 +48,7 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     completion of \FUNC{shmem\_quiet}, prior contents of the \VAR{dest} data
     object have been fetched into \VAR{fetch} local data object and the
     contents of \VAR{value} have been conditionally updated into \VAR{dest} on the
-    remote \ac{PE}.
+    target \ac{PE}.
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_compare_swap_nbi.tex
+++ b/content/shmem_atomic_compare_swap_nbi.tex
@@ -41,7 +41,7 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 
 \apidescription{
     The nonblocking conditional swap routines conditionally update a \VAR{dest}
-    data object on the specified \ac{PE} as an atomic operation and fetches the prior contents of the
+    data object on the specified target \ac{PE} as an atomic operation and fetches the prior contents of the
     \VAR{dest} data object into the \VAR{fetch} local data object.
     This routine returns after initiating the operation. The operation
     is considered complete after a subsequent call to \FUNC{shmem\_quiet}. At the

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -40,7 +40,7 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
     the default context.}
   \apiargument{IN}{source}{Symmetric address of the source data object.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} on which \VAR{source} resides 
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} on which \VAR{source} resides
     relative to the team associated with the given \VAR{ctx} when provided, or the 
     default context otherwise.}
 \end{apiarguments}
@@ -51,7 +51,7 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
 }
 
 \apireturnvalues{
-    The contents at the \VAR{source} address on the remote \ac{PE}.
+    The contents at the \VAR{source} address on the target \ac{PE}.
     The data type of the return value is the same as the type of
     the remote data object.
 }

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -41,7 +41,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     SYNOPSIS section.}
 \apiargument{IN}{value}{The operand to the atomic fetch-and-add operation.  The
     type of \VAR{value} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+\apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
      with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -55,7 +55,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 }
 
 \apireturnvalues{
-    The contents that had been at the \VAR{dest} address on the remote \ac{PE}
+    The contents that had been at the \VAR{dest} address on the target \ac{PE}
     prior to the atomic addition operation.  The data type of the return value is
     the same as the \VAR{dest}.
 }

--- a/content/shmem_atomic_fetch_add_nbi.tex
+++ b/content/shmem_atomic_fetch_add_nbi.tex
@@ -30,7 +30,7 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the atomic fetch-and-add operation.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -27,7 +27,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_and_nbi.tex
+++ b/content/shmem_atomic_fetch_and_nbi.tex
@@ -30,7 +30,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
       The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -38,7 +38,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     the default context.}
 \apiargument{OUT}{dest}{Symmetric address of the destination data object.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+\apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -50,7 +50,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
 }
 
 \apireturnvalues{
-    The contents that had been at the \dest{} address on the remote \ac{PE} prior to
+    The contents that had been at the \dest{} address on the target \ac{PE} prior to
     the increment.  The data type of the return value is the same as the \dest.
 }
 

--- a/content/shmem_atomic_fetch_inc_nbi.tex
+++ b/content/shmem_atomic_fetch_inc_nbi.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     The type of \VAR{fetch} should match that implied in the SYNOPSIS section.}
 \apiargument{OUT}{dest}{Symmetric address of the destination data object.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+\apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_nbi.tex
+++ b/content/shmem_atomic_fetch_nbi.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
     The type of \VAR{fetch} should match that implied in the SYNOPSIS section.}
   \apiargument{OUT}{source}{Symmetric address of the source data object.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -27,7 +27,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_or_nbi.tex
+++ b/content/shmem_atomic_fetch_or_nbi.tex
@@ -30,7 +30,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
       The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_xor_nbi.tex
+++ b/content/shmem_atomic_fetch_xor_nbi.tex
@@ -30,7 +30,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
       The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -38,7 +38,7 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     the default context.}
 \apiargument{OUT}{dest}{Symmetric address of the destination data object.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+\apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -42,7 +42,7 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{value}{The operand to the atomic set operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+\apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -37,9 +37,9 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
     the default context.}
   \apiargument{OUT}{dest}{Symmetric address of the destination data object.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{value}{The value to be atomically written to the remote \ac{PE}.
+  \apiargument{IN}{value}{The value to be atomically written to the target \ac{PE}.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -50,7 +50,7 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
 }
 
 \apireturnvalues{
-       The content that had been at the \dest{} address on the remote \ac{PE}
+       The content that had been at the \dest{} address on the target \ac{PE}
        prior to the swap is returned.
 }
 

--- a/content/shmem_atomic_swap_nbi.tex
+++ b/content/shmem_atomic_swap_nbi.tex
@@ -30,7 +30,7 @@ where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
   \apiargument{IN}{value}{The value to be atomically written to the remote
       \ac{PE}.
       The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies one data item from a remote \ac{PE}
+    Copies one data item from a target \ac{PE}
 }
 
 \begin{apidefinition}
@@ -22,7 +22,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     the default context.}
   \apiargument{IN}{source}{Symmetric address of the source data object.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} on which \VAR{source} resides 
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} on which \VAR{source} resides 
     relative to the team associated with the given \VAR{ctx} when provided, or the 
     default context otherwise.}
 \end{apiarguments}

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies data from a specified \ac{PE}.
+    Copies data from a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -37,13 +37,13 @@ void @\FuncDecl{shmem\_ctx\_getmem}@(shmem_ctx_t ctx, void *dest, const void *so
       The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{} arrays.
       For \FUNC{shmem\_getmem} and \FUNC{shmem\_ctx\_getmem}, elements are bytes.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
 \apidescription{
    The get routines provide a method for copying a contiguous symmetric data
-   object from a remote \ac{PE} to a contiguous data object on the local
+   object from a target \ac{PE} to a contiguous data object on the local
    \ac{PE}.  The routines return after the data has been delivered to the
    \dest{} array on the local \ac{PE}.
 }

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -39,13 +39,13 @@ void @\FuncDecl{shmem\_ctx\_getmem\_nbi}@(shmem_ctx_t ctx, void *dest, const voi
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays. For \FUNC{shmem\_getmem\_nbi} and
         \FUNC{shmem\_ctx\_getmem\_nbi}, elements are bytes.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
 \apidescription{
     The get routines provide a method for copying a contiguous symmetric data
-   object from a remote \ac{PE} to a contiguous data object on the local
+   object from a target \ac{PE} to a contiguous data object on the local
    \ac{PE}.   The routines return after initiating the operation.  The operation is considered
     complete after a subsequent call to \FUNC{shmem\_quiet}.
     At the completion of \FUNC{shmem\_quiet}, the

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The nonblocking get routines provide a method for copying data from a
-    contiguous remote data object on the specified \ac{PE} to the local data object.
+    contiguous remote data object on the specified target \ac{PE} to the local data object.
 }
 
 \begin{apidefinition}

--- a/content/shmem_ibget.tex
+++ b/content/shmem_ibget.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies blocks of strided data from a specified \ac{PE}.
+    Copies blocks of strided data from a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_ibget.tex
+++ b/content/shmem_ibget.tex
@@ -42,13 +42,13 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
         arrays.}
     \apiargument{IN}{nblocks}{Number of blocks to be copied from the \source{} array
         to the \dest{} array.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_ibget} routines provide a method for copying strided data blocks from
-    a symmetric array from a specified remote \ac{PE} to strided locations on a
+    a symmetric array from a specified target \ac{PE} to strided locations on a
     local array.  The routines return when the data has been copied into the local
     \VAR{dest} array.
 }

--- a/content/shmem_ibput.tex
+++ b/content/shmem_ibput.tex
@@ -42,7 +42,7 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
         arrays.}
     \apiargument{IN}{nblocks}{Number of blocks to be copied from the \source{} array
         to the \dest{} array.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -51,7 +51,7 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
     The \FUNC{shmem\_ibput} routines provide a method  for  copying strided data
     blocks (of size \VAR{bsize}) with stride  (specified by \VAR{sst}) of an array from a \source{} array on the
     local \ac{PE} to locations specified by stride \VAR{dst} on a \dest{} array
-    on specified remote \ac{PE}. The routines return when the data has
+    on specified target \ac{PE}. The routines return when the data has
     been copied out of the \VAR{source} array on the local \ac{PE} but not
     necessarily before the data has been delivered to the remote data object.
 }

--- a/content/shmem_ibput.tex
+++ b/content/shmem_ibput.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies strided data blocks to a specified \ac{PE}.
+    Copies strided data blocks to a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -40,13 +40,13 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
         indicates contiguous data.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_iget} routines provide a method for copying strided data elements from
-    a symmetric array from a specified remote \ac{PE} to strided locations on a
+    a symmetric array from a specified target \ac{PE} to strided locations on a
     local array.  The routines return when the data has been copied into the local
     \VAR{dest} array.
 }

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies strided data from a specified \ac{PE}.
+    Copies strided data from a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -39,7 +39,7 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
         scaled by the element size of the \source{} array. A value of \CONST{1}
         indicates contiguous data.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{} arrays.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -48,7 +48,7 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
     The \FUNC{shmem\_iput} routines provide a method  for  copying strided data
     elements (specified by \VAR{sst}) of an array from a \source{} array on the
     local \ac{PE} to locations specified by stride \VAR{dst} on a \dest{} array
-    on specified remote \ac{PE}. The routines return when the data has
+    on specified target \ac{PE}. The routines return when the data has
     been copied out of the \VAR{source} array on the local \ac{PE} but not
     necessarily before the data has been delivered to the remote data object.
 }

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies strided data to a specified \ac{PE}.
+    Copies strided data to a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies one data item to a remote \ac{PE}.
+    Copies one data item to a target \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -24,7 +24,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     The type of \dest{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{value}{The value to be transferred to \VAR{dest}.
     The type of \VAR{value} should match that implied in the SYNOPSIS section.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -33,7 +33,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     most basic types.
 
     As with \FUNC{shmem\_put}, these routines start the remote transfer and may
-    return before the data is delivered to the remote \ac{PE}.  Use
+    return before the data is delivered to the target \ac{PE}.  Use
     \FUNC{shmem\_quiet} to force completion of all remote \PUT{} transfers.
 }
 

--- a/content/shmem_pe_accessible.tex
+++ b/content/shmem_pe_accessible.tex
@@ -24,7 +24,7 @@ int @\FuncDecl{shmem\_pe\_accessible}@(int pe);
 }
 
 \apireturnvalues{
-    The return value is 1 if the specified \ac{PE} is a valid remote \ac{PE}
+    The return value is 1 if the specified \ac{PE} is a valid target \ac{PE}
     for \openshmem routines; otherwise, it is 0.
 }
 

--- a/content/shmem_pe_accessible.tex
+++ b/content/shmem_pe_accessible.tex
@@ -16,7 +16,7 @@ int @\FuncDecl{shmem\_pe\_accessible}@(int pe);
 
 \apidescription{
     \FUNC{shmem\_pe\_accessible} is a query routine that indicates whether a
-    specified \ac{PE} is accessible via \openshmem from the local \ac{PE}. The
+    specified target \ac{PE} is accessible via \openshmem from the local \ac{PE}. The
     \FUNC{shmem\_pe\_accessible} routine returns a value indicating whether the remote
     \ac{PE} is a process running from the same executable file as the local
     \ac{PE}, thereby indicating whether full support for symmetric data objects,
@@ -24,7 +24,7 @@ int @\FuncDecl{shmem\_pe\_accessible}@(int pe);
 }
 
 \apireturnvalues{
-    The return value is 1 if the specified \ac{PE} is a valid target \ac{PE}
+    The return value is 1 if the specified target \ac{PE} is a valid \ac{PE}
     for \openshmem routines; otherwise, it is 0.
 }
 

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -26,7 +26,7 @@ void *@\FuncDecl{shmem\_ptr}@(const void *dest, int pe);
 
     The \FUNC{shmem\_ptr} routine can provide efficient means to accomplish
     communication, for example when a sequence of reads and writes to a data
-    object on a remote \ac{PE} does not match the access pattern provided in an
+    object on a target \ac{PE} does not match the access pattern provided in an
     \openshmem data transfer routine like \FUNC{shmem\_put} or
     \FUNC{shmem\_iget}.
 }

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns a local pointer to a symmetric data object on the specified \ac{PE} in the world team.
+    Returns a local pointer to a symmetric data object on the specified target \ac{PE} in the world team.
 }
 
 \begin{apidefinition}
@@ -17,7 +17,7 @@ void *@\FuncDecl{shmem\_ptr}@(const void *dest, int pe);
 
 \apidescription{
     \FUNC{shmem\_ptr} returns an address that may be used to directly reference
-    \dest{} on the specified \ac{PE} in the world team.  This address can be
+    \dest{} on the specified target \ac{PE} in the world team.  This address can be
     assigned to a pointer.  After that, ordinary loads and stores to \dest{} may
     be performed.  The address returned by \FUNC{shmem\_ptr} is a local address
     to a remotely accessible data object.  Providing this address to an argument

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -38,7 +38,7 @@ void @\FuncDecl{shmem\_ctx\_putmem}@(shmem_ctx_t ctx, void *dest, const void *so
       The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source} arrays.
       For \FUNC{shmem\_putmem} and \FUNC{shmem\_ctx\_putmem}, elements are bytes.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The  put routines  provide  a method for copying data from a contiguous local
-    data object to a data object on a specified \ac{PE}.
+    data object to a data object on a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The nonblocking put routines provide a method for copying data
-    from a contiguous local data object to a data object on a specified \ac{PE}.
+    from a contiguous local data object to a data object on a specified target \ac{PE}.
 }
 
 \begin{apidefinition}

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -39,7 +39,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_nbi}@(shmem_ctx_t ctx, void *dest, const voi
   \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
     arrays. For \FUNC{shmem\_putmem\_nbi} and \FUNC{shmem\_ctx\_putmem\_nbi},
     elements are bytes.}
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The \OPR{put-with-signal} routines provide a method for copying data from a
-    contiguous local data object to a data object on a specified \ac{PE}
+    contiguous local data object to a data object on a specified target \ac{PE}
     and subsequently updating a remote flag to signal completion.
 }
 
@@ -54,7 +54,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 
 \apidescription{
     The \OPR{put-with-signal} routines provide a method for copying data from a
-    contiguous local data object to a data object on a specified \ac{PE}
+    contiguous local data object to a data object on a specified target \ac{PE}
     and subsequently updating a remote flag to signal completion. The routines
     return after the data has been copied out of the \source{} array on the
     local \ac{PE}.

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -34,7 +34,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     perform the operation. When this argument is not provided, the operation is
     performed on the default context.}
     \apiargument{OUT}{dest}{Symmetric address of the data object to be updated
-    on the remote \ac{PE}.
+    on the target \ac{PE}.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{source}{Local address of data object containing the data
     to be copied.
@@ -43,12 +43,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     arrays. For \FUNC{shmem\_putmem\_signal} and
     \FUNC{shmem\_ctx\_putmem\_signal}, elements are bytes.}
     \apiargument{OUT}{sig\_addr}{Symmetric address of the signal data object to
-    be updated on the remote \ac{PE} as a signal.}
+    be updated on the target \ac{PE} as a signal.}
     \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the
     remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
     to be performed on the remote \VAR{sig\_addr} signal data object.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -62,8 +62,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     The \VAR{sig\_op} signal operator determines the type of update to be
     performed on the remote \VAR{sig\_addr} signal data object. The completion
     of signal update based on the \VAR{sig\_op} signal operator using the
-    \VAR{signal} flag on the remote \ac{PE} indicates the delivery of its
-    corresponding \dest{} data words into the data object on the remote \ac{PE}.
+    \VAR{signal} flag on the target \ac{PE} indicates the delivery of its
+    corresponding \dest{} data words into the data object on the target \ac{PE}.
 
     An update to the \VAR{sig\_addr} signal data object through a
     \OPR{put-with-signal} routine completes as if performed atomically as described in
@@ -86,7 +86,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 
     The completion of signal update using the \VAR{signal} flag on the remote
     \ac{PE} indicates only the delivery of its corresponding \dest{} data words
-    into the data object on the remote \ac{PE}. Without a memory-ordering
+    into the data object on the target \ac{PE}. Without a memory-ordering
     operation, there is no implied ordering between the signal update of a
     \OPR{put-with-signal} routine and another data transfer. For example, the
     completion of the signal update in a sequence consisting of a put routine

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -34,7 +34,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     perform the operation. When this argument is not provided, the operation is
     performed on the default context.}
     \apiargument{OUT}{dest}{Symmetric address of the data object to be updated
-    on the remote \ac{PE}.
+    on the target \ac{PE}.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{source}{Local address of data object containing the data
     to be copied.
@@ -43,12 +43,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     arrays. For \FUNC{shmem\_putmem\_signal\_nbi} and
     \FUNC{shmem\_ctx\_putmem\_signal\_nbi}, elements are bytes.}
     \apiargument{OUT}{sig\_addr}{Symmetric address of the signal data object to
-    be updated on the remote \ac{PE} as a signal.}
+    be updated on the target \ac{PE} as a signal.}
     \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the
     remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
     to be performed on the remote \VAR{sig\_addr} signal data object.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+    \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
       with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 
@@ -63,9 +63,9 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     on the local \ac{PE} and delivered into the \dest{} array on the destination
     \ac{PE}.
 
-    The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
+    The delivery of \VAR{signal} flag on the target \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on the
-    remote \ac{PE}. Furthermore, two successive nonblocking \OPR{put-with-signal}
+    target \ac{PE}. Furthermore, two successive nonblocking \OPR{put-with-signal}
     routines, or a nonblocking \OPR{put-with-signal} routine with another data
     transfer may deliver data out of order unless a call to \FUNC{shmem\_fence}
     is introduced between the two calls.

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The nonblocking \OPR{put-with-signal} routines provide a method for copying data
-    from a contiguous local data object to a data object on a specified \ac{PE}
+    from a contiguous local data object to a data object on a specified target \ac{PE}
     and subsequently updating a remote flag to signal completion.
 }
 
@@ -54,7 +54,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
 
 \apidescription{
     The nonblocking \OPR{put-with-signal} routines provide a method for copying data
-    from a contiguous local data object to a data object on a specified \ac{PE}
+    from a contiguous local data object to a data object on a specified target \ac{PE}
     and subsequently updating a remote flag to signal completion.
 
     The routines return after initiating the operation. The operation is considered

--- a/content/shmem_signal_add.tex
+++ b/content/shmem_signal_add.tex
@@ -21,13 +21,13 @@ void @\FuncDecl{shmem\_ctx\_signal\_add}@(shmem_ctx_t ctx, uint64_t *sig_addr, u
   }
   \apiargument{OUT}{sig\_addr}{
     Symmetric address of the signal data object to be updated on the
-    remote \ac{PE}.
+    target \ac{PE}.
   }
   \apiargument{IN}{signal}{
     Unsigned 64-bit value that is used for updating the remote
     \VAR{sig\_addr} signal data object.
   }
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_signal_set.tex
+++ b/content/shmem_signal_set.tex
@@ -21,13 +21,13 @@ void @\FuncDecl{shmem\_ctx\_signal\_set}@(shmem_ctx_t ctx, uint64_t *sig_addr, u
   }
   \apiargument{OUT}{sig\_addr}{
     Symmetric address of the signal data object to be updated on the
-    remote \ac{PE}.
+    target \ac{PE}.
   }
   \apiargument{IN}{signal}{
     Unsigned 64-bit value that is used for updating the remote
     \VAR{sig\_addr} signal data object.
   }
-  \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE} relative to the team associated
+  \apiargument{IN}{pe}{\ac{PE} number of the target \ac{PE} relative to the team associated
     with the given \VAR{ctx} when provided, or the default context otherwise.}
 \end{apiarguments}
 

--- a/content/shmem_team_create_ctx.tex
+++ b/content/shmem_team_create_ctx.tex
@@ -9,7 +9,7 @@ int @\FuncDecl{shmem\_team\_create\_ctx}@(shmem_team_t team, long options, shmem
 \end{Csynopsis}
 
 \begin{apiarguments}
-  \apiargument{IN}{team}{A handle to the specified \ac{PE} team.}
+  \apiargument{IN}{team}{A handle to the specified target \ac{PE} team.}
   \apiargument{IN}{options}{
     The set of options requested for the given context.
     Multiple options may be requested by combining them with a bitwise OR

--- a/content/shmem_team_ptr.tex
+++ b/content/shmem_team_ptr.tex
@@ -27,7 +27,7 @@ void *@\FuncDecl{shmem\_team\_ptr}@(shmem_team_t team, const void *dest, int pe)
 
     The \FUNC{shmem\_team\_ptr} routine can provide efficient means to accomplish
     communication, for example when a sequence of reads and writes to a data
-    object on a remote \ac{PE} does not match the access pattern provided in an
+    object on a target \ac{PE} does not match the access pattern provided in an
     \openshmem data transfer routine like \FUNC{shmem\_put} or
     \FUNC{shmem\_iget}.
 }

--- a/content/shmem_team_ptr.tex
+++ b/content/shmem_team_ptr.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns a local pointer to a symmetric data object on the specified \ac{PE} in the specified team.
+    Returns a local pointer to a symmetric data object on the specified target \ac{PE} in the specified team.
 }
 
 \begin{apidefinition}
@@ -18,7 +18,7 @@ void *@\FuncDecl{shmem\_team\_ptr}@(shmem_team_t team, const void *dest, int pe)
 
 \apidescription{
     \FUNC{shmem\_team\_ptr} returns an address that may be used to directly reference
-    \dest{} on the specified \ac{PE} in the specified team.  This address can be assigned to a
+    \dest{} on the specified target \ac{PE} in the specified team.  This address can be assigned to a
     pointer.  After that, ordinary loads and stores to \dest{} may be
     performed.  The address returned by \FUNC{shmem\_team\_ptr} is a local address to
     a remotely accessible data object.  Providing this address to an argument of

--- a/content/shmem_team_translate_pe.tex
+++ b/content/shmem_team_translate_pe.tex
@@ -30,7 +30,7 @@ otherwise invalid, the behavior is undefined.
 }
 
 \apireturnvalues{
-The specified \ac{PE}'s number in the \VAR{dest\_team}, or a value of \CONST{-1} if any
+The specified target \ac{PE}'s number in the \VAR{dest\_team}, or a value of \CONST{-1} if any
 team handle arguments are invalid or the \VAR{src\_pe} is not in both the source and destination teams.
 }
 

--- a/content/signaling.tex
+++ b/content/signaling.tex
@@ -1,7 +1,7 @@
 This section specifies the \openshmem support for \OPR{put-with-signal},
 nonblocking \OPR{put-with-signal}, and \OPR{signal-\{add, fetch, set\}} routines. The
 put-with-signal routines provide a method for copying data from a contiguous
-local data object to a data object on a specified \ac{PE} and subsequently
+local data object to a data object on a specified target \ac{PE} and subsequently
 updating a remote flag to signal completion.
 The signal-add and signal-set routines provide methods for updating
 the signal object without the associated data transfer of a

--- a/content/synchronization_model.tex
+++ b/content/synchronization_model.tex
@@ -19,9 +19,9 @@ where they may be useful.\\
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
 {}
 &
-Waits for a symmetric variable to be updated by a remote \ac{PE}. Should be
+Waits for a symmetric variable to be updated by a target \ac{PE}. Should be
 used when computation on the local \ac{PE} cannot proceed without the value that
-the remote \ac{PE} is to update. \tabularnewline
+the target \ac{PE} is to update. \tabularnewline
 \hline
 \end{tabular}
 
@@ -57,7 +57,7 @@ issued after the \FUNC{fence} call. \tabularnewline
 {}
 &
 {All \PUT{}, \ac{AMO}, store, and nonblocking \PUT{} and \GET{} routines on symmetric data issued by a
-local \ac{PE} to all  remote \acp{PE} are guaranteed to be completed and visible
+local \ac{PE} to all  target \acp{PE} are guaranteed to be completed and visible
 once quiet returns. This routine should be used when all remote writes issued by
 a local \ac{PE} need to be visible  to all other \acp{PE} before the local
 \ac{PE} proceeds. } \tabularnewline


### PR DESCRIPTION
# Summary of changes
8f25d8c6d8ab54ea0b99785232cab886c07ae does a global search for "remote PE(s)", and replaces with "target PE(s)" in an attempt to resolve this issue:
https://github.com/orgs/openshmem-org/projects/5/views/1?pane=issue&itemId=78784978.

5e911239d2fb973ba6e48d4ff5a032923d9271ca replaces each instance of "specified PE" with "specified target PE", if so desired.

# Proposal Checklist
- [X] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
