### PR TITLE
collectives: fix inconsistency in calling preconditions

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -98,7 +98,7 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
+    Before the local \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
     conditions must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -85,7 +85,7 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       the team.
     \end{itemize}
 
-    Before any \ac{PE} calls a broadcast routine, the following conditions
+    Before the local \ac{PE} calls a broadcast routine, the following conditions
     must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -88,7 +88,7 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a collect routine, the following conditions must
+    Before the local \ac{PE} calls a collect routine, the following conditions must
     be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -295,7 +295,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a reduction routine, the following conditions
+    Before the local \ac{PE} calls a reduction routine, the following conditions
     must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_scan.tex
+++ b/content/shmem_scan.tex
@@ -90,7 +90,7 @@ by Table \ref{teamreducetypes}.
   \LibConstRef{SHMEM\_TEAM\_INVALID} or is otherwise invalid, the
   behavior is undefined.
 
-  Before any \ac{PE} calls a scan routine, the following conditions must be
+  Before the local \ac{PE} calls a scan routine, the following conditions must be
   ensured, otherwise the behavior is undefined:
   \begin{itemize}
       \item The \dest{} array on all \acp{PE} in the team is ready to accept


### PR DESCRIPTION
# Summary of changes
@stewartl318 noticed a likely typo/inconsistency throughout the collectives conditions before a collective is called.

Here is the problem sentence (emphasis mine):

> "Before _any_ PE calls [a collective having src/dest buffers] the following conditions must be ensured:
> • The dest array on all PEs in the team is ready to accept the result of the operation.
> • The source array at the local PE is ready to be read by any PE in the team."

We think this is technically wrong, and should say:

> "Before *the local* PE calls [a collective having src/dest buffers] the following conditions must be ensured..."

The reason "Before any PE..." is not quite right anymore is because it suggests the application must assure the source buffer is ready everywhere before the collective is entered anywhere, which requires user synchronization - the exact opposite of what we intended with the subsequent sentence:

> "The application does not need to synchronize to ensure that the source array is ready across all PEs prior to calling this routine"

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
